### PR TITLE
API Tokens one more time - now uses status codes effectively.

### DIFF
--- a/app/controllers/api/v1/feeds_controller.rb
+++ b/app/controllers/api/v1/feeds_controller.rb
@@ -22,7 +22,9 @@ class Api::V1::FeedsController < ActionController::Base
 
   def authenticate_user
     @current_user = User.find_by_authentication_token(params[:token])
-    render :json => "Token is invalid.".to_json unless @current_user
+    unless @current_user
+      render :json => "Token is invalid.".to_json, status: 401
+    end
   end
 
   def current_user

--- a/app/controllers/api/v1/meta_data_controller.rb
+++ b/app/controllers/api/v1/meta_data_controller.rb
@@ -9,7 +9,9 @@ class Api::V1::MetaDataController < ApplicationController
 
   def authenticate_user
     @current_user = User.find_by_authentication_token(params[:token])
-    render :json => "Token is invalid.".to_json unless @current_user
+    unless @current_user
+      render :json => "Token is invalid.".to_json, status: 401
+    end
   end
 
   def current_user

--- a/spec/apis/v1/authentication_spec.rb
+++ b/spec/apis/v1/authentication_spec.rb
@@ -4,10 +4,18 @@ describe "API errors", :type => :api do
   let!(:user) { FactoryGirl.create(:user_with_growls) }
   let(:url) { "http://api.hungrlr.dev/v1/feeds/#{user.display_name}" }
 
-  it "making a request with no token" do
-    get "#{url}.json", :token => ""
-    error = "Token is invalid."
-    last_response.body.should eql(error.to_json)
+  context "making a request with no token" do
+
+    it "returns the message 'Token is invalid'" do
+      get "#{url}.json", :token => ""
+      error = "Token is invalid."
+      last_response.body.should eql(error.to_json)
+    end
+
+    it "returns an error 401" do
+      get "#{url}.json", :token => ""
+      last_response.status.should == 401
+    end
   end
 
 end

--- a/spec/apis/v1/feeds_spec.rb
+++ b/spec/apis/v1/feeds_spec.rb
@@ -8,7 +8,7 @@ describe 'api/v1/feed', type: :api do
     # visit new_user_session_path(user)
     let(:url) { "http://api.hungrlr.com/v1/feeds/#{user.display_name}" }
     before(:each) do
-      get "#{url}.json"
+      get "#{url}.json", token: user.authentication_token
     end
     describe "json" do
       it "returns a successful response" do


### PR DESCRIPTION
Added status codes to feeds_controller and meta_data_controller api authentication. Moving forward any successful calls to API will need to include token: user.authentication_token.
